### PR TITLE
Fix Frog Boots

### DIFF
--- a/final_island/data/final_island/enchantment/frog.json
+++ b/final_island/data/final_island/enchantment/frog.json
@@ -12,5 +12,19 @@
         "base": 0,
         "per_level_above_first": 0
     },
-    "max_level": 5
+    "max_level": 5,
+    "effects": {
+        "minecraft:attributes": [
+            {
+                "attribute": "minecraft:jump_strength",
+                "amount": {
+                    "type": "minecraft:linear",
+                    "base": 0.12,
+                    "per_level_above_first": 0.10
+                },
+                "operation": "add_value",
+                "id": "customenchant:highjump"
+            }
+        ]
+    }
 }


### PR DESCRIPTION
They currently just give the jump boost effect, this will not work if Jump boost potions are added in the furture.

This makes them attribute based and will stack with jump boost